### PR TITLE
Fix Chinese translation

### DIFF
--- a/src/OnTopReplica/Strings.resx
+++ b/src/OnTopReplica/Strings.resx
@@ -459,12 +459,6 @@ You can enable click-through later</value>
 	<data name="MenuOp80TT" xml:space="preserve">
     <value>Sets OnTopReplica to 80% opacity.</value>
   </data>
-	<data name="MenuOp80" xml:space="preserve">
-    <value>80%</value>
-  </data>
-	<data name="MenuOp80TT" xml:space="preserve">
-    <value>Sets OnTopReplica to 80% opacity.</value>
-  </data>
 	<data name="MenuOp75" xml:space="preserve">
     <value>75%</value>
   </data>

--- a/src/OnTopReplica/Strings.zh-Hans.resx
+++ b/src/OnTopReplica/Strings.zh-Hans.resx
@@ -435,11 +435,59 @@ To return to normal mode anytime, activate OnTopReplica by clicking on the task 
   <data name="MenuOp100TT" xml:space="preserve">
     <value>把OnTopReplica设为完全不透明状态</value>
   </data>
-  <data name="MenuOp25" xml:space="preserve">
-    <value>25%</value>
+  <data name="MenuOp95" xml:space="preserve">
+    <value>95%</value>
   </data>
-  <data name="MenuOp25TT" xml:space="preserve">
-    <value>把OnTopReplica的不透明度设为25%</value>
+  <data name="MenuOp95TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为95%</value>
+  </data>
+  <data name="MenuOp90" xml:space="preserve">
+    <value>90%</value>
+  </data>
+  <data name="MenuOp90TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为90%</value>
+  </data>
+  <data name="MenuOp85" xml:space="preserve">
+    <value>85%</value>
+  </data>
+  <data name="MenuOp85TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为85%</value>
+  </data>
+  <data name="MenuOp80" xml:space="preserve">
+    <value>80%</value>
+  </data>
+  <data name="MenuOp80TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为80%</value>
+  </data>
+  <data name="MenuOp75" xml:space="preserve">
+    <value>75%</value>
+  </data>
+  <data name="MenuOp75TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为75%</value>
+  </data>
+  <data name="MenuOp70" xml:space="preserve">
+    <value>70%</value>
+  </data>
+  <data name="MenuOp70TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为70%</value>
+  </data>
+  <data name="MenuOp65" xml:space="preserve">
+    <value>65%</value>
+  </data>
+  <data name="MenuOp65TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为65%</value>
+  </data>
+  <data name="MenuOp60" xml:space="preserve">
+    <value>60%</value>
+  </data>
+  <data name="MenuOp60TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为60%</value>
+  </data>
+  <data name="MenuOp55" xml:space="preserve">
+    <value>55%</value>
+  </data>
+  <data name="MenuOp55TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为55%</value>
   </data>
   <data name="MenuOp50" xml:space="preserve">
     <value>50%</value>
@@ -447,11 +495,41 @@ To return to normal mode anytime, activate OnTopReplica by clicking on the task 
   <data name="MenuOp50TT" xml:space="preserve">
     <value>把OnTopReplica的不透明度设为50%</value>
   </data>
-  <data name="MenuOp75" xml:space="preserve">
-    <value>75%</value>
+  <data name="MenuOp45" xml:space="preserve">
+    <value>45%</value>
   </data>
-  <data name="MenuOp75TT" xml:space="preserve">
-    <value>把OnTopReplica的不透明度设为75%</value>
+  <data name="MenuOp45TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为45%</value>
+  </data>
+  <data name="MenuOp40" xml:space="preserve">
+    <value>40%</value>
+  </data>
+  <data name="MenuOp40TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为40%</value>
+  </data>
+  <data name="MenuOp35" xml:space="preserve">
+    <value>35%</value>
+  </data>
+  <data name="MenuOp35TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为35%</value>
+  </data>
+  <data name="MenuOp30" xml:space="preserve">
+    <value>30%</value>
+  </data>
+  <data name="MenuOp30TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为30%</value>
+  </data>
+  <data name="MenuOp25" xml:space="preserve">
+    <value>25%</value>
+  </data>
+  <data name="MenuOp25TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为25%</value>
+  </data>
+  <data name="MenuOp20" xml:space="preserve">
+    <value>20%</value>
+  </data>
+  <data name="MenuOp20TT" xml:space="preserve">
+    <value>把OnTopReplica的不透明度设为20%</value>
   </data>
   <data name="MenuOpacity" xml:space="preserve">
     <value>不透明度</value>
@@ -496,7 +574,7 @@ To return to normal mode anytime, activate OnTopReplica by clicking on the task 
     <value>选择是否记忆窗口大小和位置，并在下次运行时恢复</value>
   </data>
   <data name="MenuReduce" xml:space="preserve">
-    <value>最小化</value>
+    <value>显示窗口 / 最小化到托盘</value>
   </data>
   <data name="MenuReduceTT" xml:space="preserve">
     <value>最小化到任务栏上</value>
@@ -651,5 +729,26 @@ OnTopReplica将被关闭以安装更新</value>
   </data>
   <data name="UpdateTitle" xml:space="preserve">
     <value>OnTopReplica更新</value>
+  </data>
+  <data name="RegionsBottom" xml:space="preserve">
+    <value>底部</value>
+  </data>
+  <data name="RegionsLeft" xml:space="preserve">
+    <value>左</value>
+  </data>
+  <data name="RegionsRight" xml:space="preserve">
+    <value>右</value>
+  </data>
+  <data name="RegionsTop" xml:space="preserve">
+    <value>顶部</value>
+  </data>
+  <data name="RegionsX" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="RegionsY" xml:space="preserve">
+    <value>Y</value>
+  </data>
+  <data name="SettingsHotKeyClickThrough" xml:space="preserve">
+    <value>穿过模式切换</value>
   </data>
 </root>

--- a/src/OnTopReplica/Strings.zh-TW.resx
+++ b/src/OnTopReplica/Strings.zh-TW.resx
@@ -169,7 +169,7 @@
     <value>準備更新</value>
   </data>
   <data name="MenuOpacity" xml:space="preserve">
-    <value>透明度</value>
+    <value>不透明度</value>
   </data>
   <data name="AboutTranslators" xml:space="preserve">
     <value>翻譯者：{0}</value>
@@ -228,14 +228,53 @@
   <data name="GroupSwitchModeStatusDisabled" xml:space="preserve">
     <value>同時選擇多個視窗來打開。</value>
   </data>
+  <data name="MenuOp95TT" xml:space="preserve">
+    <value>設定不透明度為 95%。</value>
+  </data>
+  <data name="MenuOp90TT" xml:space="preserve">
+    <value>設定不透明度為 90%。</value>
+  </data>
+  <data name="MenuOp85TT" xml:space="preserve">
+    <value>設定不透明度為 85%。</value>
+  </data>
+  <data name="MenuOp80TT" xml:space="preserve">
+    <value>設定不透明度為 80%。</value>
+  </data>
   <data name="MenuOp75TT" xml:space="preserve">
-    <value>設定透明度為 75%。</value>
+    <value>設定不透明度為 75%。</value>
+  </data>
+  <data name="MenuOp70TT" xml:space="preserve">
+    <value>設定不透明度為 70%。</value>
+  </data>
+  <data name="MenuOp65TT" xml:space="preserve">
+    <value>設定不透明度為 65%。</value>
+  </data>
+  <data name="MenuOp60TT" xml:space="preserve">
+    <value>設定不透明度為 60%。</value>
+  </data>
+  <data name="MenuOp55TT" xml:space="preserve">
+    <value>設定不透明度為 55%。</value>
   </data>
   <data name="MenuOp50TT" xml:space="preserve">
-    <value>設定透明度為 50%。</value>
+    <value>設定不透明度為 50%。</value>
+  </data>
+  <data name="MenuOp45TT" xml:space="preserve">
+    <value>設定不透明度為 45%。</value>
+  </data>
+  <data name="MenuOp40TT" xml:space="preserve">
+    <value>設定不透明度為 40%。</value>
+  </data>
+  <data name="MenuOp35TT" xml:space="preserve">
+    <value>設定不透明度為 35%。</value>
+  </data>
+  <data name="MenuOp30TT" xml:space="preserve">
+    <value>設定不透明度為 30%。</value>
   </data>
   <data name="MenuOp25TT" xml:space="preserve">
-    <value>設定透明度為 25%。</value>
+    <value>設定不透明度為 25%。</value>
+  </data>
+  <data name="MenuOp20TT" xml:space="preserve">
+    <value>設定不透明度為 20%。</value>
   </data>
   <data name="MenuOp100TT" xml:space="preserve">
     <value>設定為不透明。</value>
@@ -361,7 +400,7 @@
     <value>最小化OnTopReplica至工作列或系統列。</value>
   </data>
   <data name="MenuReduce" xml:space="preserve">
-    <value>最小化</value>
+    <value>顯示視窗 / 最小化到託盤</value>
   </data>
   <data name="AboutLicenseContent" xml:space="preserve">
     <value>Microsoft Reciprocal (MS-RL)</value>
@@ -579,14 +618,53 @@ OnTopReplica 會在下次啟動的時候提醒你。</value>
   <data name="MenuOpen" xml:space="preserve">
     <value>打開</value>
   </data>
+  <data name="MenuOp95" xml:space="preserve">
+    <value>95%</value>
+  </data>
+  <data name="MenuOp90" xml:space="preserve">
+    <value>90%</value>
+  </data>
+  <data name="MenuOp85" xml:space="preserve">
+    <value>85%</value>
+  </data>
+  <data name="MenuOp80" xml:space="preserve">
+    <value>80%</value>
+  </data>
   <data name="MenuOp75" xml:space="preserve">
     <value>75%</value>
+  </data>
+  <data name="MenuOp70" xml:space="preserve">
+    <value>70%</value>
+  </data>
+  <data name="MenuOp65" xml:space="preserve">
+    <value>65%</value>
+  </data>
+  <data name="MenuOp60" xml:space="preserve">
+    <value>60%</value>
+  </data>
+  <data name="MenuOp55" xml:space="preserve">
+    <value>55%</value>
   </data>
   <data name="MenuOp50" xml:space="preserve">
     <value>50%</value>
   </data>
+  <data name="MenuOp45" xml:space="preserve">
+    <value>45%</value>
+  </data>
+  <data name="MenuOp40" xml:space="preserve">
+    <value>40%</value>
+  </data>
+  <data name="MenuOp35" xml:space="preserve">
+    <value>35%</value>
+  </data>
+  <data name="MenuOp30" xml:space="preserve">
+    <value>30%</value>
+  </data>
   <data name="MenuOp25" xml:space="preserve">
     <value>25%</value>
+  </data>
+  <data name="MenuOp20" xml:space="preserve">
+    <value>20%</value>
   </data>
   <data name="MenuFitDouble" xml:space="preserve">
     <value>2:1 兩倍</value>
@@ -638,5 +716,8 @@ OnTopReplica 會在下次啟動的時候提醒你。</value>
   </data>
   <data name="RegionsY" xml:space="preserve">
     <value>Y</value>
+  </data>
+  <data name="SettingsHotKeyClickThrough" xml:space="preserve">
+    <value>穿透模式切換</value>
   </data>
 </root>

--- a/src/OnTopReplica/Strings.zh.resx
+++ b/src/OnTopReplica/Strings.zh.resx
@@ -282,7 +282,7 @@
     <value>模式</value>
   </data>
   <data name="FullscreenModeAlwaysOnTop" xml:space="preserve">
-    <value>总在置顶</value>
+    <value>总是置顶</value>
   </data>
   <data name="FullscreenModeAlwaysOnTopTT" xml:space="preserve">
     <value>强制OnTopReplica置顶。</value>
@@ -429,26 +429,104 @@
   <data name="MenuOp100TT" xml:space="preserve">
     <value>设置OnTopReplica不透明。</value>
   </data>
-  <data name="MenuOp25" xml:space="preserve">
-    <value>25%</value>
+  <data name="MenuOp95" xml:space="preserve">
+    <value>95%</value>
   </data>
-  <data name="MenuOp25TT" xml:space="preserve">
-    <value>设置OnTopReplica有25%透明度。</value>
+  <data name="MenuOp95TT" xml:space="preserve">
+    <value>设置OnTopReplica有95%不透明。</value>
   </data>
-  <data name="MenuOp50" xml:space="preserve">
-    <value>50%</value>
+  <data name="MenuOp90" xml:space="preserve">
+    <value>90%</value>
   </data>
-  <data name="MenuOp50TT" xml:space="preserve">
-    <value>设置OnTopReplica有50%透明度。</value>
+  <data name="MenuOp90TT" xml:space="preserve">
+    <value>设置OnTopReplica有90%不透明。</value>
+  </data>
+  <data name="MenuOp85" xml:space="preserve">
+    <value>85%</value>
+  </data>
+  <data name="MenuOp85TT" xml:space="preserve">
+    <value>设置OnTopReplica有85%不透明。</value>
+  </data>
+  <data name="MenuOp80" xml:space="preserve">
+    <value>80%</value>
+  </data>
+  <data name="MenuOp80TT" xml:space="preserve">
+    <value>设置OnTopReplica有80%不透明。</value>
   </data>
   <data name="MenuOp75" xml:space="preserve">
     <value>75%</value>
   </data>
   <data name="MenuOp75TT" xml:space="preserve">
-    <value>设置OnTopReplica有75%透明度。</value>
+    <value>设置OnTopReplica有75%不透明。</value>
+  </data>
+  <data name="MenuOp70" xml:space="preserve">
+    <value>70%</value>
+  </data>
+  <data name="MenuOp70TT" xml:space="preserve">
+    <value>设置OnTopReplica有70%不透明。</value>
+  </data>
+  <data name="MenuOp65" xml:space="preserve">
+    <value>65%</value>
+  </data>
+  <data name="MenuOp65TT" xml:space="preserve">
+    <value>设置OnTopReplica有65%不透明。</value>
+  </data>
+  <data name="MenuOp60" xml:space="preserve">
+    <value>60%</value>
+  </data>
+  <data name="MenuOp60TT" xml:space="preserve">
+    <value>设置OnTopReplica有60%不透明。</value>
+  </data>
+  <data name="MenuOp55" xml:space="preserve">
+    <value>55%</value>
+  </data>
+  <data name="MenuOp55TT" xml:space="preserve">
+    <value>设置OnTopReplica有55%不透明。</value>
+  </data>
+  <data name="MenuOp50" xml:space="preserve">
+    <value>50%</value>
+  </data>
+  <data name="MenuOp50TT" xml:space="preserve">
+    <value>设置OnTopReplica有50%不透明。</value>
+  </data>
+  <data name="MenuOp45" xml:space="preserve">
+    <value>45%</value>
+  </data>
+  <data name="MenuOp45TT" xml:space="preserve">
+    <value>设置OnTopReplica有45%不透明。</value>
+  </data>
+  <data name="MenuOp40" xml:space="preserve">
+    <value>40%</value>
+  </data>
+  <data name="MenuOp40TT" xml:space="preserve">
+    <value>设置OnTopReplica有40%不透明。</value>
+  </data>
+  <data name="MenuOp35" xml:space="preserve">
+    <value>35%</value>
+  </data>
+  <data name="MenuOp35TT" xml:space="preserve">
+    <value>设置OnTopReplica有35%不透明。</value>
+  </data>
+  <data name="MenuOp30" xml:space="preserve">
+    <value>30%</value>
+  </data>
+  <data name="MenuOp30TT" xml:space="preserve">
+    <value>设置OnTopReplica有30%不透明。</value>
+  </data>
+  <data name="MenuOp25" xml:space="preserve">
+    <value>25%</value>
+  </data>
+  <data name="MenuOp25TT" xml:space="preserve">
+    <value>设置OnTopReplica有25%不透明。</value>
+  </data>
+  <data name="MenuOp20" xml:space="preserve">
+    <value>20%</value>
+  </data>
+  <data name="MenuOp20TT" xml:space="preserve">
+    <value>设置OnTopReplica有20%不透明。</value>
   </data>
   <data name="MenuOpacity" xml:space="preserve">
-    <value>透明度</value>
+    <value>不透明度</value>
   </data>
   <data name="MenuOpen" xml:space="preserve">
     <value>打开</value>
@@ -490,7 +568,7 @@
     <value>切换OnTopReplica是否存储最后的位置和大小以便下次启动时使用。</value>
   </data>
   <data name="MenuReduce" xml:space="preserve">
-    <value>最小化</value>
+    <value>显示窗口 / 最小化到托盘</value>
   </data>
   <data name="MenuReduceTT" xml:space="preserve">
     <value>最小化OnTopReplica至任务栏或托盘。</value>
@@ -661,5 +739,8 @@ OnTopReplica会关闭并应用更新。</value>
   </data>
   <data name="RegionsY" xml:space="preserve">
     <value>Y</value>
+  </data>
+  <data name="SettingsHotKeyClickThrough" xml:space="preserve">
+    <value>穿透模式切换</value>
   </data>
 </root>


### PR DESCRIPTION
Fix Chinese translation.
Simplified Chinese uses file `Strings.zh.resx` instead of `Strings.zh-Hans.resx`.
File `Strings.zh-Hans.resx` looks deprecated.
